### PR TITLE
Omit username/password/clientID values if ""

### DIFF
--- a/main.js
+++ b/main.js
@@ -33,6 +33,18 @@ ipcMain.on('brokerSettings', (evt, message) => {
 			brokerDisconnect = Promise.resolve();
 		}
 
+		if(data.username === ""){
+			delete data.username;
+		}
+
+		if(data.password === ""){
+			delete data.password;
+		}
+
+		if(data.clientId === ""){
+			delete data.clientId;
+		}
+
 		brokerDisconnect
 			.then(function(){
 


### PR DESCRIPTION
When the input fields in the connection form are left empty, an empty string is passed to the main thread for connecting to the MQTT broker. This can cause connection errors when the broker is public and doesn't require a username / password.

If these values are omitted from the connection form, they will be omitted from the actual connection request too.

Addresses #11 